### PR TITLE
Update SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+.yarn
 .env

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@assemblyscript/loader": "^0.27.22",
     "@hiveio/dhive": "^1.2.8",
-    "@vsc.eco/sdk": "^0.1.2",
+    "@vsc.eco/sdk": "^0.1.4",
     "assemblyscript": "^0.27.22",
     "assemblyscript-json": "^1.1.0",
     "asyncify-wasm": "^1.2.1",


### PR DESCRIPTION
Fix missing `getEnv` export due to old SDK version.

Also adds `.yarn` folder to gitignore.