### PR TITLE
allow relative assemblyscript imports for deploy

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -17,6 +17,7 @@ import * as mktemp from "mktemp";
 import { encodePayload } from "dag-jose-utils";
 import { bech32 } from "bech32";
 import { fetch } from "cross-fetch";
+import * as path from "path";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -283,12 +283,16 @@ async function compileAS(args: { scriptPath: string }): Promise<CompileResult> {
     {
       stdout: stdout,
       readFile: async (filename: string, baseDir: string) => {
-        // console.log(filename, baseDir)
         try {
+          let fullPath;
+
           if (filename === "input.ts") {
-            return (await fs.readFile(scriptPath)).toString();
+            fullPath = scriptPath;
+          } else {
+            fullPath = path.resolve(path.dirname(scriptPath), filename);
           }
-          return (await fs.readFile(filename)).toString();
+
+          return (await fs.readFile(fullPath)).toString();
         } catch {
           return null;
         }


### PR DESCRIPTION
allows relative assemblyscript imports, didnt work before 

![image](https://github.com/user-attachments/assets/8b8e81aa-8ee8-4c3d-9774-91faf36a97a5)


before

![image](https://github.com/user-attachments/assets/10e24bdb-df10-4485-8e20-d1c3217c3f24)


after

![image](https://github.com/user-attachments/assets/34c32b38-21f6-4d61-802d-fca497d7246a)
